### PR TITLE
Size for smaller width devices is now up to date

### DIFF
--- a/style.css
+++ b/style.css
@@ -1020,11 +1020,18 @@ h2:hover {
   }
   #forwards {
     height: 175px;
-    width: 175px;
+    width: 300px;
   }
   .circle-chart {
     height: 175px;
-    width: 175px;
+    width: 300px;
+  }
+  .circle-number {
+    padding-top: 0px;
+    font-size: 40px;
+  }
+  .circle-text {
+    font-size: 20px;
   }
   .aside-right,
   .table-container{


### PR DESCRIPTION
The smaller screen widths looked a bit odd since there was a lot of white space before. Increased the width of the circle charts to display across the full width of the screen.